### PR TITLE
Inject melis configuration with .env file insted of virtualhost

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -1,0 +1,2 @@
+MELIS_PLATFORM=development
+MELIS_MODULE=MelisDemoCms

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"melisplatform/melis-core": "^5.2",
 		"melisplatform/melis-dbdeploy": "^5.2",
 		"melisplatform/melis-installer": "^5.2",
-		"melisplatform/melis-marketplace": "^5.2"
+		"melisplatform/melis-marketplace": "^5.2",
+		"vlucas/phpdotenv": "^5.6"
 	},
 	"scripts": {
 		"post-update-cmd": [

--- a/public/index.php
+++ b/public/index.php
@@ -41,5 +41,18 @@ if (file_exists(__DIR__ . '/../config/development.config.php')) {
     $appConfig = ArrayUtils::merge($appConfig, require __DIR__ . '/../config/development.config.php');
 }
 
+// Inject melis configuration without virtualhost variables
+if(file_exists(__DIR__ . '/../.env')){
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../');
+    $dotenv->load();
+    if(is_array($_ENV)){
+        foreach ($_ENV as $key => $value) {
+            if($key == 'MELIS_MODULE' || $key == 'MELIS_PLATFORM'){
+                putenv("$key=$value");
+            }
+        }
+    }
+}
+
 // Run the application!
 Application::init($appConfig)->run();


### PR DESCRIPTION
This will make it possible for melis to get the environment variables (MELIS PLATFORM, MELIS MODULE) from .env file instead of the virtual host just by adding them in the .env file (eventually for dev environment) then run the platform via [herd](https://herd.laravel.com/) or "[php -S](https://www.php.net/manual/en/features.commandline.webserver.php)"