### PR TITLE
Add Laminas fork repositories for PHP 8.4/8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,14 @@
 		"mvc",
 		"framework"
 	],
+	"repositories": [
+		{ "type": "vcs", "url": "https://github.com/melisplatform/laminas-mail" },
+		{ "type": "vcs", "url": "https://github.com/melisplatform/laminas-mime" },
+		{ "type": "vcs", "url": "https://github.com/melisplatform/laminas-crypt" },
+		{ "type": "vcs", "url": "https://github.com/melisplatform/laminas-file" }
+	],
 	"require": {
-		"php": "^8.1|^8.3",
+		"php": "^8.1|^8.3|^8.4|^8.5",
 		"melisplatform/melis-asset-manager": "^5.3",
 		"melisplatform/melis-composerdeploy": "^5.3.3",
 		"melisplatform/melis-core": "^5.3.31",


### PR DESCRIPTION
## What

Adds `repositories` entries pointing at the **maintained melisplatform forks** of the
abandoned/archived Laminas components, and declares 8.4/8.5 in the root `php` constraint:

```json
"repositories": [
  { "type": "vcs", "url": "https://github.com/melisplatform/laminas-mail" },
  { "type": "vcs", "url": "https://github.com/melisplatform/laminas-mime" },
  { "type": "vcs", "url": "https://github.com/melisplatform/laminas-crypt" },
  { "type": "vcs", "url": "https://github.com/melisplatform/laminas-file" }
]
```

## Why

`laminas-mail/mime/crypt/file` are abandoned/archived upstream and cap at PHP 8.3.
The forks (mail 2.26.0, mime 2.13.0, crypt 3.13.0, file 2.14.0) declare 8.4/8.5 and fix
the implicit-nullable deprecations, so the resolver can build a PHP 8.4/8.5 tree.

## Validated

Full skeleton dependency resolution **succeeds on PHP 8.4.22** with these forks +
`melis-core` carrying the servicemanager unpin (#26) and serializer ^3 (#27).

## Depends on
- melisplatform/melis-core#26 (servicemanager) + melisplatform/melis-core#27 (serializer) — **released**
- then regenerate `composer.lock` on PHP 8.4

Part of the PHP 8.4 effort (melisplatform/melis-core#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)